### PR TITLE
fix(envvars): Env Var issues and documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ cdk-notifier --help
 #
 #Flags:
 #  -d, --delete                delete comments when no changes are detected for a specific tag id (default true)
-#  -u, --url string            Gitlab url (default "https://gitlab.com")
-#      --gitlab-token string   Gitlab token used to post comments to MR
+#  -u, --url string            Gitlab url (default "https://gitlab.com"). If not set will lookup for env var GITLAB_BASE_URL
+#      --gitlab-token string   Gitlab token used to post comments to MR. If not set will lookup for env var GITLAB_TOKEN
 #  -p  --gitlab-pid int        Gitlab project ID for merge request. If not set will lookup for env var CI_MERGE_REQUEST_PROJECT_ID
 #  -h, --help                  help for cdk-notifier
 #  -l, --log-file string       path to cdk log file (default "./cdk.log")
-#  -m, --merge-request-id int  Id of gitlab merge request. If not set will lookup for env var $CI_JOB_TOKEN
+#  -m, --merge-request-id int  Id of gitlab merge request. If not set will lookup for env var CI_MERGE_REQUEST_IID
 #  -t, --tag-id string         unique identifier for stack within pipeline (default "stack")
 #  -v, --verbosity string      Log level (debug, info, warn, error, fatal, panic) (default "info")
 #      --version               version for cdk-notifier

--- a/config/app.go
+++ b/config/app.go
@@ -32,9 +32,9 @@ func (e *ValidationError) Error() string {
 
 const (
 	// EnvGitlabToken Name of environment variable for Gitlab token
-	EnvGitlabToken = "CI_JOB_TOKEN"
+	EnvGitlabToken = "GITLAB_TOKEN"
 	// EnvMergeRequestID Name of environment variable for pull request url
-	EnvMergeRequestID = "CI_MERGE_REQUEST_ID"
+	EnvMergeRequestID = "CI_MERGE_REQUEST_IID"
 	// EnvGitlabUrl Name of environment variable for Gitlab Base Url
 	EnvGitlabUrl = "GITLAB_BASE_URL"
 	// EnvGitlabPid Name of environment variable for Gitlab Project ID
@@ -59,6 +59,9 @@ func (a *AppConfig) Init() error {
 			panic(err)
 		}
 		a.ProjectID = int(pidInt64)
+	}
+	if a.GitlabUrl == "" {
+		a.GitlabUrl = readFromEnv(EnvGitlabUrl)
 	}
 	if a.MergeRequest == 0 {
 		prNumber, err := readMergeRequestFromEnv()

--- a/config/app_test.go
+++ b/config/app_test.go
@@ -80,6 +80,7 @@ func TestAppConfig_Init(t *testing.T) {
 				ProjectID:    1,
 				GitlabToken:  "some-token",
 				MergeRequest: 23,
+				GitlabUrl:    "https://gitlab.com/",
 			},
 			err: nil,
 		},
@@ -102,6 +103,7 @@ func TestAppConfig_Init(t *testing.T) {
 				GitlabToken:  "changedToken",
 				MergeRequest: 12,
 				ProjectID:    2,
+				GitlabUrl:    "https://gitlab.com/",
 			},
 			err: nil,
 		},
@@ -122,6 +124,7 @@ func TestAppConfig_Init(t *testing.T) {
 				ProjectID:    1,
 				GitlabToken:  "",
 				MergeRequest: 23,
+				GitlabUrl:    "https://gitlab.com/",
 			},
 			err: &ValidationError{"gitlab-token", EnvGitlabToken},
 		},
@@ -134,6 +137,7 @@ func TestAppConfig_Init(t *testing.T) {
 			envVars: map[string]string{
 				EnvGitlabPid:   "1",
 				EnvGitlabToken: "some-token",
+				EnvGitlabUrl:   "https://gitlab.com/",
 			},
 			expectedConfig: AppConfig{
 				LogFile:      "./cdk.log",
@@ -141,6 +145,7 @@ func TestAppConfig_Init(t *testing.T) {
 				ProjectID:    1,
 				GitlabToken:  "some-token",
 				MergeRequest: 0,
+				GitlabUrl:    "https://gitlab.com/",
 			},
 			err: nil,
 		},
@@ -153,12 +158,14 @@ func TestAppConfig_Init(t *testing.T) {
 			},
 			envVars: map[string]string{
 				EnvMergeRequestID: "23as",
+				EnvGitlabUrl:      "https://gitlab.com/",
 			},
 			expectedConfig: AppConfig{
 				LogFile:      "./cdk.log",
 				ProjectID:    1,
 				GitlabToken:  "some-token",
 				MergeRequest: 0,
+				GitlabUrl:    "https://gitlab.com/",
 			},
 			err: &strconv.NumError{
 				Func: "ParseInt",


### PR DESCRIPTION
Incorrect gitlab CI var for merge request ID, url env var not passed if arg is missing and reworked token handling as CI_JOB_TOKEN is currently not able to call the Gitlab API. See https://gitlab.com/gitlab-org/gitlab/-/issues/17511 for details. Recommend project/group access token as a work around